### PR TITLE
Support users without profile pictures.

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -73,7 +73,9 @@ class Provider extends AbstractProvider
             'nickname'     => Arr::get($user, 'username'),
             'name'         => null,
             'email'        => null,
-            'avatar'       => Arr::get($user, 'threads_profile_picture_url'),
+            'avatar'       => array_key_exists('threads_profile_picture_url', $user)
+                                ? $user['threads_profile_picture_url']
+                                : null,
         ]);
     }
 }


### PR DESCRIPTION
This prevents a crash when a user doesn't have an avatar.

Without this we experience this error:
```
ERROR: Error handling Threads callback {"exception":"Undefined array key \"threads_profile_picture_url\"","stack_trace":"#0 /[REDACTED]/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(255): Illuminate\\Foundation\\Bootstrap\\HandleExceptions->handleError(2, 'Undefined array...', '[REDACTED]', 84)\n#1 [REDACTED]/vendor/socialiteproviders/threads/Provider.php(84)
```